### PR TITLE
feat: add signup pause flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Account
+  - added `ALLOW_SIGNUPS` environment flag (default `true`) to pause new email/social registrations while keeping existing user logins available.
 - Analytics
   - implementation-ready integration analytics architecture spec covering GA4, GSC, and Plausible (`docs/integration-analytics-architecture-v1.md`)
   - analytics ingestion models: `AnalyticsSourceSnapshot`, `AnalyticsFactDaily`, and `AnalyticsSyncCursor`

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -42,7 +42,7 @@ class CustomAccountAdapter(DefaultAccountAdapter):
 
     def is_open_for_signup(self, request):
         """Allow operators to pause new registrations without affecting existing users."""
-        return settings.ALLOW_SIGNUPS
+        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request)
 
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         """
@@ -110,7 +110,7 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def is_open_for_signup(self, request, sociallogin):
         """Mirror email signup gating for social-account auto-signups."""
-        return settings.ALLOW_SIGNUPS
+        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request, sociallogin)
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django_q.tasks import async_task
@@ -38,6 +39,10 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         """Ensure username exists even when signup form does not request it."""
         if not user.username:
             user.username = self._generate_unique_username_from_email(user.email)
+
+    def is_open_for_signup(self, request):
+        """Allow operators to pause new registrations without affecting existing users."""
+        return settings.ALLOW_SIGNUPS
 
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         """
@@ -102,6 +107,10 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     Custom adapter to automatically generate usernames from email addresses
     during social authentication signup, bypassing the username selection page.
     """
+
+    def is_open_for_signup(self, request, sociallogin):
+        """Mirror email signup gating for social-account auto-signups."""
+        return settings.ALLOW_SIGNUPS
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/core/tests/test_signup_gating.py
+++ b/core/tests/test_signup_gating.py
@@ -1,6 +1,20 @@
-from pathlib import Path
-
+from django.template.loader import render_to_string
 from django.test import RequestFactory, override_settings
+from django.urls import path
+from django.views.generic import TemplateView
+
+urlpatterns = [
+    path("", TemplateView.as_view(), name="landing"),
+    path("accounts/login/", TemplateView.as_view(), name="account_login"),
+    path("accounts/signup/", TemplateView.as_view(), name="account_signup"),
+    path("app/", TemplateView.as_view(), name="home"),
+    path("blog/", TemplateView.as_view(), name="blog_posts"),
+    path("changelog/", TemplateView.as_view(), name="changelog"),
+    path("docs/<slug:category>/<slug:page>/", TemplateView.as_view(), name="docs_page"),
+    path("pricing/", TemplateView.as_view(), name="pricing"),
+    path("privacy/", TemplateView.as_view(), name="privacy_policy"),
+    path("terms/", TemplateView.as_view(), name="terms_of_service"),
+]
 
 from core.adapters import CustomAccountAdapter, CustomSocialAccountAdapter
 
@@ -33,15 +47,12 @@ def test_social_signup_adapter_uses_same_signup_gate():
     assert CustomSocialAccountAdapter().is_open_for_signup(request, sociallogin=None) is False
 
 
+@override_settings(ROOT_URLCONF=__name__)
 def test_signup_closed_template_tells_existing_users_to_log_in():
-    template_path = (
-        Path(__file__).resolve().parents[2] / "frontend/templates/account/signup_closed.html"
-    )
-
-    content = template_path.read_text(encoding="utf-8")
+    content = render_to_string("account/signup_closed.html")
 
     assert "Signups paused" in content
     assert "Existing users can continue using the product as usual" in content
-    assert "account_login" in content
+    assert 'href="/accounts/login/"' in content
     assert 'name="email"' not in content
     assert 'name="password1"' not in content

--- a/core/tests/test_signup_gating.py
+++ b/core/tests/test_signup_gating.py
@@ -19,6 +19,13 @@ def test_account_signup_adapter_can_close_new_signups():
     assert CustomAccountAdapter().is_open_for_signup(request) is False
 
 
+@override_settings(ALLOW_SIGNUPS=True)
+def test_social_signup_adapter_defaults_open_for_signups():
+    request = RequestFactory().get("/accounts/google/login/callback/")
+
+    assert CustomSocialAccountAdapter().is_open_for_signup(request, sociallogin=None) is True
+
+
 @override_settings(ALLOW_SIGNUPS=False)
 def test_social_signup_adapter_uses_same_signup_gate():
     request = RequestFactory().get("/accounts/google/login/callback/")

--- a/core/tests/test_signup_gating.py
+++ b/core/tests/test_signup_gating.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from django.test import RequestFactory, override_settings
+
+from core.adapters import CustomAccountAdapter, CustomSocialAccountAdapter
+
+
+@override_settings(ALLOW_SIGNUPS=True)
+def test_account_signup_adapter_defaults_open_for_signups():
+    request = RequestFactory().get("/accounts/signup/")
+
+    assert CustomAccountAdapter().is_open_for_signup(request) is True
+
+
+@override_settings(ALLOW_SIGNUPS=False)
+def test_account_signup_adapter_can_close_new_signups():
+    request = RequestFactory().get("/accounts/signup/")
+
+    assert CustomAccountAdapter().is_open_for_signup(request) is False
+
+
+@override_settings(ALLOW_SIGNUPS=False)
+def test_social_signup_adapter_uses_same_signup_gate():
+    request = RequestFactory().get("/accounts/google/login/callback/")
+
+    assert CustomSocialAccountAdapter().is_open_for_signup(request, sociallogin=None) is False
+
+
+def test_signup_closed_template_tells_existing_users_to_log_in():
+    template_path = (
+        Path(__file__).resolve().parents[2] / "frontend/templates/account/signup_closed.html"
+    )
+
+    content = template_path.read_text(encoding="utf-8")
+
+    assert "Signups paused" in content
+    assert "Existing users can continue using the product as usual" in content
+    assert "account_login" in content
+    assert 'name="email"' not in content
+    assert 'name="password1"' not in content

--- a/frontend/templates/account/signup_closed.html
+++ b/frontend/templates/account/signup_closed.html
@@ -1,11 +1,11 @@
 {% extends "base_landing.html" %}
 
 {% block content %}
-<div class="flex justify-center items-center px-4 py-16 my-4 sm:px-6 lg:px-8">
-  <div class="space-y-6 w-full max-w-md text-center">
+<main class="flex justify-center items-center px-4 py-16 my-4 sm:px-6 lg:px-8">
+  <section class="space-y-6 w-full max-w-md text-center" aria-labelledby="signup-closed-heading">
     <div>
       <p class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Signups paused</p>
-      <h1 class="mt-3 text-3xl font-extrabold text-gray-900">TuxSEO is not accepting new accounts right now.</h1>
+      <h1 id="signup-closed-heading" class="mt-3 text-3xl font-extrabold text-gray-900">TuxSEO is not accepting new accounts right now.</h1>
       <p class="mt-4 text-sm leading-6 text-gray-600">
         Existing users can continue using the product as usual. New account creation is paused for now.
       </p>
@@ -14,6 +14,6 @@
        class="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-gray-800 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
       Log in to your account
     </a>
-  </div>
-</div>
+  </section>
+</main>
 {% endblock content %}

--- a/frontend/templates/account/signup_closed.html
+++ b/frontend/templates/account/signup_closed.html
@@ -1,0 +1,19 @@
+{% extends "base_landing.html" %}
+
+{% block content %}
+<div class="flex justify-center items-center px-4 py-16 my-4 sm:px-6 lg:px-8">
+  <div class="space-y-6 w-full max-w-md text-center">
+    <div>
+      <p class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Signups paused</p>
+      <h1 class="mt-3 text-3xl font-extrabold text-gray-900">TuxSEO is not accepting new accounts right now.</h1>
+      <p class="mt-4 text-sm leading-6 text-gray-600">
+        Existing users can continue using the product as usual. New account creation is paused for now.
+      </p>
+    </div>
+    <a href="{% url 'account_login' %}"
+       class="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-gray-800 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+      Log in to your account
+    </a>
+  </div>
+</div>
+{% endblock content %}

--- a/tuxseo/settings.py
+++ b/tuxseo/settings.py
@@ -26,7 +26,12 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from structlog_sentry import SentryProcessor
 
 from tuxseo.logging_utils import scrubbing_callback
-from tuxseo.posthog_logs import PostHogLogsEmitter, PostHogLogsProcessor, ensure_exception_fields, redact_event
+from tuxseo.posthog_logs import (
+    PostHogLogsEmitter,
+    PostHogLogsProcessor,
+    ensure_exception_fields,
+    redact_event,
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -289,6 +294,7 @@ ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_CONFIRM_EMAIL_ON_GET = True
+ALLOW_SIGNUPS = env.bool("ALLOW_SIGNUPS", default=True)
 ACCOUNT_ADAPTER = "core.adapters.CustomAccountAdapter"
 ACCOUNT_FORMS = {
     "signup": "core.forms.CustomSignUpForm",
@@ -396,9 +402,7 @@ SITEMAP_SYNC_RETRY_BACKOFF_SECONDS = max(
 )
 SITEMAP_SYNC_MAX_INDEX_DEPTH = max(0, env.int("SITEMAP_SYNC_MAX_INDEX_DEPTH", default=2))
 SITEMAP_SYNC_MAX_CHILD_SITEMAPS = max(1, env.int("SITEMAP_SYNC_MAX_CHILD_SITEMAPS", default=50))
-SITEMAP_SYNC_LOCK_TTL_SECONDS = max(
-    60, env.int("SITEMAP_SYNC_LOCK_TTL_SECONDS", default=3600)
-)
+SITEMAP_SYNC_LOCK_TTL_SECONDS = max(60, env.int("SITEMAP_SYNC_LOCK_TTL_SECONDS", default=3600))
 
 
 def extract_from_record(logger, name, event_dict):


### PR DESCRIPTION
## Summary
- add `ALLOW_SIGNUPS` env flag (defaults to `true`) for pausing new registrations
- gate both email/password and social-account auto-signups through the same setting
- add a closed signup page that points existing users to login
- add regression coverage for the adapters and closed-state template
- update CHANGELOG.md

## Verification
- `uv run pytest core/tests/test_signup_gating.py core/tests/test_forms.py::TestCustomSignUpFormTurnstile -q`
- `uv run --with ruff ruff check tuxseo/settings.py core/adapters.py core/tests/test_signup_gating.py`
- `uv run --with ruff ruff format --check tuxseo/settings.py core/adapters.py core/tests/test_signup_gating.py`

Note: full DB-backed signup page test could not run in this container because the configured Postgres host `db` is not resolvable here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ALLOW_SIGNUPS` configuration option to pause new user registrations while keeping existing users able to log in. A signups-closed page guides users accordingly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rasulkireev/TuxSEO/pull/249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->